### PR TITLE
Send email with referral code 143

### DIFF
--- a/venue/tasks.py
+++ b/venue/tasks.py
@@ -397,24 +397,18 @@ def send_reset_password(email, name, code, language):
     )
 
 
-def send_email(*, template, email, name, code, subject, language):
+def send_email(*, template, email, subject, language, **kwargs):
     """
     Generic function to send email
     :param template: path to template to be used
     :param email: email to send
-    :param name: user name
-    :param code:
     :param subject: email subject
     :param language: language code (en, fr, etc..)
     :return:
     """
+    kwargs['domain'] = settings.VENUE_FRONTEND,
     with translation_on(language):
-        context = {
-            'domain': settings.VENUE_FRONTEND,
-            'name': name,
-            'code': code
-        }
-        html = get_template(template).render(context)
+        html = get_template(template).render(kwargs)
         mail = postmark.emails.send(
             From=settings.POSTMARK_SENDER_EMAIL,
             To=email,

--- a/venue/templates/venue/email_referral.html
+++ b/venue/templates/venue/email_referral.html
@@ -1,0 +1,36 @@
+{% extends 'venue/base_email.html' %}
+{% load i18n %}
+
+{% block title %}{% blocktrans %}Email invitation{% endblocktrans %}{% endblock %}
+{% block preheader %}{% blocktrans %}Use a link from email to sign up{% endblocktrans %}{% endblock %}
+{% block media_content %}
+    <tr>
+        <td class="wrapper">
+            <table border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td>
+                        <p>{% blocktrans %}Hi {{ name }},{% endblocktrans %}</p>
+                        <p>{% blocktrans %}Thank you for signing up to use Venue!{% endblocktrans %}</p>
+                        <p>{% blocktrans %}Kindly press the confirm button below and start using Venue right away.{% endblocktrans %}</p>
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
+                            <tbody>
+                            <tr>
+                                <td align="left">
+                                    <table border="0" cellpadding="0" cellspacing="0">
+                                        <tbody>
+                                        <tr>
+                                            <td><a href="{{ domain }}/signup?code={{ code }}"
+                                                   target="_blank">{% blocktrans %}Sign Up{% endblocktrans %}</a></td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+{% endblock %}

--- a/venue/views.py
+++ b/venue/views.py
@@ -2553,6 +2553,91 @@ def get_information_about_referrals(request):
     return Response({'referrals': referrals})
 
 # ------------------------
+# Referrals views
+# ------------------------
+SEND_EMAILS_SCHEMA = AutoSchema(
+    manual_fields=[
+        coreapi.Field(
+            'emails',
+            required=False,
+            location='form',
+            schema=coreschema.Array(description='A list of email'),
+        ),
+        coreapi.Field(
+            'email',
+            required=False,
+            location='form',
+            schema=coreschema.String(description='A single email')
+        )
+    ]
+)
+
+
+@api_view(['POST'])
+@permission_classes((IsAuthenticated,))
+@schema(SEND_EMAILS_SCHEMA)
+def send_emails_with_referral_code(request):
+    """ Send email with referral code
+    One of two fields (`email` or `emails`) should be filled.
+
+    ### Response
+
+    * Status code 200 (at least one message was sent)
+
+            {
+                "success": <boolean: true>,
+                "result": <list: EmailSentResult>
+            }
+
+        * `success` - Result of the request
+        * Each `EmailSentResult` array contains the following info
+
+                {
+                    "email": <string>,
+                    "sent": <boolean>,
+                    "error": <string>
+                }
+
+            * `email` - email address that was used
+            * `sent` - result of the execution for this email
+            * `error` - error for this email, filled only if `sent` is `false
+
+    * Status code 422 (wrong payload structure is provided)
+
+            {
+                "success": <boolean: false>,
+                "error": <string>
+            }
+
+        * `success` - Result of the request (false)
+        * `error` - description of an error
+
+
+    * Status code 400 (no messages have been sent)
+
+            {
+                "success": <boolean: false>,
+                "result": <list: EmailSentResult>
+                "error": <string>
+            }
+
+        * `success` - Result of the request (false)
+        * `error` - description of an error
+        * Each `EmailSentResult` array contains the following info
+
+                {
+                    "email": <string>,
+                    "sent": <boolean>,
+                    "error": <string>
+                }
+
+            * `email` - email address that was used
+            * `sent` - result of the execution for this email
+            * `error` - error for this email
+    """
+    return Response({})
+
+# ------------------------
 # Debugging view functions
 # ------------------------
 

--- a/volentix/urls.py
+++ b/volentix/urls.py
@@ -23,10 +23,9 @@ from venue.views import (
     get_notifications, dismiss_notification, create_forum_profile,
     get_forum_sites, get_forum_profiles, get_signatures, get_points_breakdown,
     confirm_email_change, trigger_data_update, check_task_status, logout_user,
-    get_information_about_referrals
+    send_emails_with_referral_code, get_information_about_referrals
 )
 from rest_framework.documentation import include_docs_urls
-from django.views.static import serve
 from django.conf.urls import url
 from django.conf import settings
 from django.contrib import admin
@@ -76,7 +75,8 @@ urlpatterns = [
     url(r'^api/manage/delete-account/', delete_account),
     url(r'^api/manage/verify-otp-code/', verify_2fa_code),
     url(r'^api/manage/disable-two-factor-auth/', disable_2fa),
-    url(r'^api/manage/dismiss-notification/', dismiss_notification)
+    url(r'^api/manage/dismiss-notification/', dismiss_notification),
+    url(r'^api/manage/send-referrals/', send_emails_with_referral_code),
 ]
 
 


### PR DESCRIPTION
Closes #143 

Right now it's a PR to confirm request schema. Could you please check a doc string and let me know if you are ok with it? 

My idea is:

- 200: All goes well.
- 422: Errors in a payload (required field is missing or no email was provided)

**You can find response payloads in the doc string.** 

And one more point, @shawnlauzon could you confirm that you really want to use two fields (`email` and/or `emails`). Because I'm thinking that maybe it will be better to use only `emails` and send a list with only one element instead of another one field? 

```
{
    "emails": ["some-test@email.com"]
}
```
vs
```
{
    "email": "some-test@email.com"
}
```