### PR TITLE
use alpine image instead of debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3.6
-RUN apt-get update -y && \
-    pip install --upgrade pip && \
-    apt-get -y install libpq-dev libncurses5-dev git gettext --no-install-recommends && \
+FROM python:3.6-alpine3.8
+RUN pip install --upgrade pip && \
+    apk --no-cache -U add gcc build-base linux-headers  \
+    postgresql-dev ncurses-dev git gettext libffi-dev libressl-dev && \
     pip install git+https://github.com/Supervisor/supervisor.git@363283c71ed11054bdd8756b78e7777f160dcf05 && \
-    apt-get remove git -y && apt-get autoremove -y && apt-get autoclean -y
+    apk del git
+
 COPY ./requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cd /code && python manage.py collectstatic --noinput
 cd /code && python manage.py migrate
 exec "$@"


### PR DESCRIPTION
Use alpine instead of a debian based image. 

This change dramatically reduces image size to 1.2GB vs 530MB.

P.S. the first build of the cache takes more time(because we have to build some dependencies) but when the cache is ready a build takes about 1m 30s instead of 2.5 - 3 min