### PR TITLE
Rewrite leader board data view using SQL

### DIFF
--- a/venue/migrations/0009_leader_board_stored_procedures.py
+++ b/venue/migrations/0009_leader_board_stored_procedures.py
@@ -1,0 +1,83 @@
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def forum_stats_procedure():
+    return """
+    CREATE OR REPLACE FUNCTION forum_stats()
+        RETURNS TABLE(
+          site_name TEXT,
+          total_posts BIGINT,
+          total_users BIGINT
+        ) AS $body$
+        SELECT S.name::TEXT AS site_name,
+               count(DISTINCT FPT.id) AS total_posts,
+               count(DISTINCT FP.id) AS total_users
+        FROM venue_forumsite S
+               JOIN venue_forumprofile FP ON S.id = FP.forum_id
+               JOIN venue_forumpost FPT ON FP.id = FPT.forum_profile_id
+               JOIN venue_userprofile UP ON FP.user_profile_id = UP.id
+               JOIN auth_user U ON UP.user_id = U.id
+        WHERE U.is_active IS TRUE AND FP.active IS TRUE AND FP.verified IS TRUE
+        GROUP BY name;
+        $body$
+        LANGUAGE SQL;
+    """
+
+
+def leader_board_procedure():
+    return """
+        CREATE OR REPLACE FUNCTION leader_board_data(P_TOTAL_POINTS NUMERIC, P_VTX_AVAILABLE INT, P_MAX_REFERRALS INT)
+          RETURNS TABLE(
+            username     TEXT,
+            total_posts  BIGINT,
+            total_points NUMERIC,
+            total_tokens BIGINT,
+            rank         INT
+          ) AS $body$
+        WITH POSTS AS (SELECT P.forum_profile_id,
+                              coalesce(sum(P.total_points), 0.0) AS total_points,
+                              coalesce(count(P.id), 0) AS total_count
+                       FROM venue_forumpost P
+                       WHERE credited = TRUE
+                       GROUP BY P.forum_profile_id),
+             REFERREALS AS (SELECT referrer_id, coalesce(bonus, 0) AS bonus
+                            FROM (SELECT bonus, referrer_id,
+                                         row_number() OVER (PARTITION BY referrer_id ORDER BY granted_at) AS rownum
+                                  FROM venue_referral) tmp
+                            WHERE ROWNUM <= P_MAX_REFERRALS),
+             RANK AS (SELECT rank :: INT, user_profile_id
+                      FROM (SELECT id, rank, timestamp, user_profile_id, row_number() OVER (
+                        PARTITION BY user_profile_id ORDER BY timestamp DESC
+                        ) AS row_number
+                            FROM venue_ranking) AS tmp
+                      WHERE row_number = 1)
+        SELECT U.username :: TEXT,
+               coalesce(sum(P.total_count), 0) :: BIGINT AS total_posts,
+               coalesce(sum(P.total_points), 0.0) :: NUMERIC AS total_points,
+               coalesce(coalesce(sum(P.total_points), 0) / P_TOTAL_POINTS * P_VTX_AVAILABLE + coalesce(sum(R.bonus), 0),
+                        0) :: BIGINT AS total_tokens,
+               RK.rank
+        FROM venue_userprofile UP
+               JOIN venue_forumprofile FP ON UP.id = FP.user_profile_id
+               JOIN auth_user U ON UP.user_id = U.id
+               LEFT JOIN POSTS AS P ON FP.id = P.forum_profile_id
+               LEFT JOIN REFERREALS R ON UP.id = R.referrer_id
+               LEFT JOIN RANK RK ON UP.id = RK.user_profile_id
+        WHERE FP.active IS TRUE AND verified IS TRUE AND U.is_active IS TRUE AND UP.email_confirmed IS TRUE
+        GROUP BY U.id, RK.RANK;
+        $body$
+        LANGUAGE SQL;
+    """
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('venue', '0008_referral'),
+    ]
+
+    operations = [
+        migrations.RunSQL(leader_board_procedure()),
+        migrations.RunSQL(forum_stats_procedure())
+    ]

--- a/venue/views.py
+++ b/venue/views.py
@@ -918,68 +918,47 @@ def get_leaderboard_data(request):
         * `value` - Number of users for the forum
     """
     response = {}
-    user_profiles = UserProfile.objects.filter(
-        user__is_active=True,
-        email_confirmed=True,
-    )
-    leaderboard_data = []
-    for user_profile in user_profiles:
-        fps = user_profile.forum_profiles.filter(active=True, verified=True)
-        if fps.count():
-            user_data = {
-                'username': user_profile.user.username,
-                'rank': user_profile.get_ranking(),
-                'total_posts': user_profile.total_posts,
-                'total_points': user_profile.total_points,
-                'total_tokens': user_profile.total_tokens
-            }
-            leaderboard_data.append(user_data)
+    leader_board_data = UserProfile.get_leader_board_data()
     # Get site-wide stats
-    users_with_fp = [x for x in user_profiles if x.with_forum_profile]
     response['sitewide'] = {
         'available_tokens': '{:,}'.format(config.VTX_AVAILABLE),
-        'total_users': len(users_with_fp),
-        'total_posts': int(sum([x.total_posts for x in users_with_fp])),
-        'total_points': int(sum([x.total_points for x in users_with_fp]))
+        'total_users': len(leader_board_data),
+        'total_posts': int(sum([x['total_posts'] for x in leader_board_data])),
+        'total_points': int(sum([x['total_points'] for x in leader_board_data]))
     }
     # Order according to amount of tokens
-    if leaderboard_data:
-        leaderboard_data = sorted(leaderboard_data, key=itemgetter('rank'))
-        response['rankings'] = leaderboard_data
+    if leader_board_data:
+        leader_board_data = sorted(leader_board_data, key=itemgetter('rank'))
+        response['rankings'] = leader_board_data
         if request.user.is_anonymous():
             response['userstats'] = {}
         else:
-            user_profile = UserProfile.objects.get(user=request.user)
-            total_tokens = user_profile.total_tokens
+            user_data = next(
+                (i for i in leader_board_data if i['username'] == request.user.username),
+                {}
+            )
             response['userstats'] = {
-                'overall_rank': user_profile.get_ranking(),
-                'total_tokens': int(round(total_tokens, 0))
+                'overall_rank': user_data.get('username'),
+                'total_tokens': int(round(user_data.get('total_tokens'), 0))
             }
     # Generate forum stats
     forum_stats = {
         'posts': [],
-        'users': []}
-    sites = ForumSite.objects.all()
+        'users': []
+    }
+    sites_stats = ForumSite.get_stats()
     colors = ['#2a96b6', '#5a2998', '#b62da9']
-    for i, site in enumerate(sites):
-        total_posts = 0
-        fps = site.forum_profiles.filter(
-            user_profile__user__is_active=True,
-            active=True,
-            verified=True
-        )
-        for fp in fps:
-            total_posts += fp.total_posts
-        total_users = fps.count()
+    colors_count = len(colors)
+    for i, site_data in enumerate(sites_stats):
         forum_stats['posts'].append({
-            'forumSite': site.name,
-            'value': total_posts,
-            'color': colors[i]
+            'forumSite': site_data['site_name'],
+            'value': site_data['total_posts'],
+            'color': colors[i % colors_count]
         })
         forum_stats['users'].append({
-            'forumSite': site.name,
-            'value': total_users,
-            'color': colors[i]
+            'forumSite': site_data['site_name'],
+            'value': site_data['total_users'],
+            'color': colors[i % colors_count]
         })
     response['forumstats'] = forum_stats
     response['success'] = True


### PR DESCRIPTION
Closes  https://github.com/Volentix/venue/issues/119. 

Please be careful, I added PSQL functions, query time is reduced but some logic was moved to the Postgres site. 

Result before / after: 
```
GET /api/retrieve/leaderboard-data/ => generated 87044 bytes in 19534 msecs
GET /api/retrieve/leaderboard-data/ => generated 87051 bytes in 260 msecs
```
**UPDATED**:
Set correct issue link