### PR TITLE
add branch prefix to the ci cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ jobs:
     - setup_remote_docker
     - restore_cache:
         keys:
-        - v1-{{ checksum "Dockerfile" }}-{{ checksum "requirements.txt" }}
+        - venue-server-{{ checksum "Dockerfile" }}-{{ checksum "requirements.txt" }}-{{ .Branch }}
+        - venue-server-{{ checksum "Dockerfile" }}-{{ checksum "requirements.txt" }}-master
         paths:
         - /caches/venueserver.tar
 
@@ -44,7 +45,7 @@ jobs:
 
     - save_cache:
         name: Save cache to the circle CI
-        key: v1-{{ checksum "Dockerfile" }}-{{ checksum "requirements.txt" }}
+        key: venue-server-{{ checksum "Dockerfile" }}-{{ checksum "requirements.txt" }}-{{ .Branch }}
         paths:
         - /caches/venueserver.tar
 


### PR DESCRIPTION
Fix a problem with the build time. I added a branch prefix and master cache like a backup.
@realrhys I can cherry pick this commit to the performance branch too but I see that migrations with the data take too much time and I can't really fix it. The only way I see it's changing migrations by the [fixtures](https://docs.djangoproject.com/en/2.1/howto/initial-data/) and do not touch them during the CI build