### PR TITLE
Remove useless data from the table

### DIFF
--- a/venue/tasks.py
+++ b/venue/tasks.py
@@ -272,6 +272,8 @@ def compute_ranking():
             send_websocket_signal('refresh')
     # Save the global total points in redis
     settings.REDIS_DB.set('global_total_points', global_total)
+    # Remove useless data from the table
+    Ranking.clean_ranking()
     return {'total': global_total, 'points': user_points}
 
 


### PR DESCRIPTION
Closes #167.

Keep only last week's data and only one raw per day for a user. 
@joemarct Please feel free to advise me about rewriting with an ORM. I can't find a fast way to keep only the latest raw per day without a query per user.
