### PR TITLE
update paramiko

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ mccabe==0.6.1
 meld3==1.0.2
 model-mommy==1.6.0
 olefile==0.44
-paramiko==2.4.0
+paramiko==2.4.1
 parso==0.1.0
 pexpect==4.2.1
 pickleshare==0.7.4


### PR DESCRIPTION
#164

Updated `paramiko` to 2.4.1 but there is no updated yep for the `pycrypto `. 