### PR TITLE
generate mo files during the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
         name: Tag image and push to server
         command: |
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker-compose run --rm web django-admin compilemessages
               TAG=v0.1.$CIRCLE_BUILD_NUM
               docker build --cache-from=venueserver -t volentixlabs/venueserver:$TAG .
               echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ generated
 .coverage
 .tox/
 .env
+*.mo


### PR DESCRIPTION
Closes  #197.

`*.mo` files are added to the `.gitignore` and are generated during the image tagging. 