### PR TITLE
Manually handle the retry of tasks

### DIFF
--- a/venue/scrapers/bitcointalk.py
+++ b/venue/scrapers/bitcointalk.py
@@ -55,6 +55,9 @@ class BitcoinTalk(object):
         self.response_text = response.text
         self.status_code = response.status_code
         self.error_info['status_code'] = self.status_code
+        self.error_info['response_text'] = self.response_text
+        if self.status_code:
+            raise ScraperError('Request did not succeed', self.error_info)
         self.soup = BeautifulSoup(response.content, 'html.parser')
 
     def get_profile(self, user_id, fallback=None, test_config=None):

--- a/venue/views.py
+++ b/venue/views.py
@@ -35,7 +35,7 @@ from .models import (ForumPost, ForumProfile, ForumSite, ForumUserRank, Notifica
                      compute_total_points, Referral)
 from .tasks import (get_user_position, send_deletion_confirmation, send_email_change_confirmation,
                     send_email_confirmation, send_reset_password, set_scraping_rate, update_data,
-                    verify_profile_signature, send_email)
+                    verify_profile_signature, send_email, wait_for_results)
 from .utils import RedisTemp, decrypt_data, encrypt_data, check_language_exists, translation_on
 
 
@@ -554,8 +554,7 @@ def check_profile(request):
         data.get('forum_user_id'),
         user.id
     )
-    task.get()
-    info = task.result
+    info = wait_for_results(task.id)
     response['found'] = info['found']
     if info['found']:
         if info['status_code'] == 200 and info['position']:


### PR DESCRIPTION
Closes #227

Other changes:
- Raise scraper error when status code is not 200, not just when error is encountered in page parsing