### PR TITLE
Display Verto address and email in user profiles table

### DIFF
--- a/venue/admin.py
+++ b/venue/admin.py
@@ -39,7 +39,7 @@ admin.site.register(Signature)
 
 
 class UserProfileAdmin(admin.ModelAdmin):
-    list_display = ['user', 'email_confirmed', 'receive_emails', 'user_email']
+    list_display = ['user', 'user_email', 'email_confirmed', 'verto_address']
     fields = ['user', 'language', 'otp_secret',
               'enabled_2fa', 'email_confirmed',
               'receive_emails', 'user_email',


### PR DESCRIPTION
This affects the display of the User Profiles table in the admin (`/admin/venue/userprofile/`) in such a way that the Verto address (if any) is also displayed alongside the user's email address.

This is done so that admins can easily check which Venue users have linked their accounts to their Verto wallets.